### PR TITLE
Pull Mantine UI theme from context

### DIFF
--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Dashboard.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Dashboard.tsx
@@ -33,7 +33,7 @@ function {{ cookiecutter.plugin_name }}DashboardItem({
  */
 export function render{{ cookiecutter.plugin_name }}DashboardItem(target: HTMLElement, context: any) {
     createRoot(target).render(
-        <MantineProvider>
+        <MantineProvider theme={context.theme} defaultColorScheme={context.colorScheme}>
             <{{ cookiecutter.plugin_name }}DashboardItem context={context} />
         </MantineProvider>
     );

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -44,7 +44,7 @@ function {{ cookiecutter.plugin_name }}Panel({
  */
 export function render{{ cookiecutter.plugin_name }}Panel(target: HTMLElement, context: any) {
     createRoot(target).render(
-        <MantineProvider>
+        <MantineProvider theme={context.theme} defaultColorScheme={context.colorScheme}>
             <{{ cookiecutter.plugin_name }}Panel context={context} />
         </MantineProvider>
     );


### PR DESCRIPTION
This PR fixes the Mantine UI issue reported on the main Inventree repository, https://github.com/inventree/InvenTree/issues/9190 It is a simple change to pull in the theme from Inventree via the supplied context.