### PR TITLE
Added missing MantineProvider

### DIFF
--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/main.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/main.tsx
@@ -1,9 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import { MantineProvider } from '@mantine/core'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <MantineProvider>
+      <App />
+    </MantineProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
`MantineProvider` is missing from `main.tsx`, so if you run `npm run dev` nothing is displayed on the screen.