### PR TITLE
Frontend translation support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Check Compiled Output
         run: |
           cd output/MyCustomPlugin
+          test -d frontend/src/locales/de/messages.ts
+          test -d frontend/src/locales/en/messages.ts
           test -d my_custom_plugin/static
           test -d my_custom_plugin/static/assets
           test -f my_custom_plugin/static/Panel.js

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,10 +63,12 @@ jobs:
         run: |
           cd output/MyCustomPlugin/frontend
           npm install
-          npm run build
           npm run translate
+          npm run build
           test -f MyCustomPlugin/my_custom_plugin/static/Panel.js
           test -f MyCustomPlugin/my_custom_plugin/static/Dashboard.js
           test -f MyCustomPlugin/my_custom_plugin/static/.vite/manifest.json
           test -f MyCustomPlugin/frontend/src/locales/de/messages.po
-          test -f MyCustomPlugin/frontend/src/locales/de/messages.ts
+          test -f MyCustomPlugin/frontend/src/locales/es/messages.ts
+          test -f MyCustomPlugin/my_custom_plugin/static/locales/de/messages.ts
+          test -f MyCustomPlugin/my_custom_plugin/static/locales/en/messages.ts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Check Compiled Output
         run: |
           cd output/MyCustomPlugin
+          test -d my_custom_plugin/static
+          test -d my_custom_plugin/static/assets
           test -f my_custom_plugin/static/Panel.js
           test -f my_custom_plugin/static/Dashboard.js
           test -f my_custom_plugin/static/.vite/manifest.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,10 +65,9 @@ jobs:
           npm install
           npm run translate
           npm run build
-          test -f MyCustomPlugin/my_custom_plugin/static/Panel.js
-          test -f MyCustomPlugin/my_custom_plugin/static/Dashboard.js
-          test -f MyCustomPlugin/my_custom_plugin/static/.vite/manifest.json
-          test -f MyCustomPlugin/frontend/src/locales/de/messages.po
-          test -f MyCustomPlugin/frontend/src/locales/es/messages.ts
-          test -f MyCustomPlugin/my_custom_plugin/static/locales/de/messages.ts
-          test -f MyCustomPlugin/my_custom_plugin/static/locales/en/messages.ts
+      - name: Check Compiled Output
+        run: |
+          cd output/MyCustomPlugin
+          test -f my_custom_plugin/static/Panel.js
+          test -f my_custom_plugin/static/Dashboard.js
+          test -f my_custom_plugin/static/.vite/manifest.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,4 +64,9 @@ jobs:
           cd output/MyCustomPlugin/frontend
           npm install
           npm run build
-  
+          npm run translate
+          test -f MyCustomPlugin/my_custom_plugin/static/Panel.js
+          test -f MyCustomPlugin/my_custom_plugin/static/Dashboard.js
+          test -f MyCustomPlugin/my_custom_plugin/static/.vite/manifest.json
+          test -f MyCustomPlugin/frontend/src/locales/de/messages.po
+          test -f MyCustomPlugin/frontend/src/locales/de/messages.ts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,11 +65,11 @@ jobs:
           npm install
           npm run translate
           npm run build
+          test -f src/locales/de/messages.ts
+          test -f src/locales/en/messages.ts
       - name: Check Compiled Output
         run: |
           cd output/MyCustomPlugin
-          test -d frontend/src/locales/de/messages.ts
-          test -d frontend/src/locales/en/messages.ts
           test -d my_custom_plugin/static
           test -d my_custom_plugin/static/assets
           test -f my_custom_plugin/static/Panel.js

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # Default generated plugin dir
 ./MyCustomPlugin
+
+*Zone.Identifier

--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,5 @@ cython_debug/
 # Default generated plugin dir
 ./MyCustomPlugin
 
+# Windows files
 *Zone.Identifier

--- a/plugin_creator/frontend.py
+++ b/plugin_creator/frontend.py
@@ -19,16 +19,12 @@ def frontend_features() -> dict:
 
 def all_features() -> dict:
     """Select all features by default."""
-    return {
-        key: True for key in frontend_features().keys()
-    }
+    return {key: True for key in frontend_features().keys()}
 
 
 def no_features() -> dict:
     """Select no features by default."""
-    return {
-        key: False for key in frontend_features().keys()
-    }
+    return {key: False for key in frontend_features().keys()}
 
 
 def enable_translation() -> bool:
@@ -46,19 +42,19 @@ def select_features() -> dict:
         Choice(
             title=title,
             checked=True,
-        ) for title in frontend_features().values()
+        )
+        for title in frontend_features().values()
     ]
 
     selected = questionary.checkbox(
-        "Select frontend features to enable",
-        choices=choices
+        "Select frontend features to enable", choices=choices
     ).ask()
 
-    selected_keys = [key for key, value in frontend_features().items() if value in selected]
+    selected_keys = [
+        key for key, value in frontend_features().items() if value in selected
+    ]
 
-    return {
-        key: key in selected_keys for key in frontend_features().keys()
-    }
+    return {key: key in selected_keys for key in frontend_features().keys()}
 
 
 def remove_frontend(plugin_dir: str) -> None:
@@ -71,20 +67,16 @@ def update_frontend(plugin_dir: str, context: dict) -> None:
 
     info("Cleaning up frontend files...")
 
-    features = context['frontend']['features'] or []
-    translation = context['frontend'].get('translation', False)
+    features = context["frontend"]["features"] or []
+    translation = context["frontend"].get("translation", False)
 
     # Remove features which are not needed
     for feature in frontend_features().keys():
         if not features.get(feature, False):
             info(f"- Removing unused frontend feature: {feature}")
 
-            remove_file(
-                plugin_dir,
-                'frontend',
-                'src',
-                f'{feature.capitalize()}.tsx'
-            )
+            remove_file(plugin_dir, "frontend", "src", f"{feature.capitalize()}.tsx")
 
     if not translation:
-        remove_dir(plugin_dir, 'frontend', 'src', 'locales')
+        remove_dir(plugin_dir, "frontend", "src", "locales")
+        remove_file(plugin_dir, "frontend", ".linguirc")

--- a/plugin_creator/frontend.py
+++ b/plugin_creator/frontend.py
@@ -79,4 +79,5 @@ def update_frontend(plugin_dir: str, context: dict) -> None:
 
     if not translation:
         remove_dir(plugin_dir, "frontend", "src", "locales")
+        remove_file(plugin_dir, "frontend", "src", "locales.tsx")
         remove_file(plugin_dir, "frontend", ".linguirc")

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/.github/workflows/ci.yaml
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
         run: |
           cd frontend
           npm install
+          {% if cookiecutter.frontend.translation -%}
+          npm run translate
+          {%- endif %}
           npm run build
           npm run lint
   {%- endif -%}

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/.github/workflows/pypi.yaml
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/.github/workflows/pypi.yaml
@@ -32,6 +32,9 @@ jobs:
         run: |
           cd frontend
           npm install
+          {% if cookiecutter.frontend.translation -%}
+          npm run translate
+          {%- endif %}
           npm run build
       {%- endif %}
       - name: Build Binary

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/.gitlab-ci.yml
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/.gitlab-ci.yml
@@ -27,5 +27,8 @@ frontend:
     - npm install
   script:
     - npm run build
+    {% if cookiecutter.frontend.translation -%}
+    - npm run translate
+    {%- endif %}
     - npm run lint
 {%- endif -%}

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/.linguirc
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/.linguirc
@@ -9,7 +9,7 @@
         "ru",
         "zh_Hans",
         "zh_Hant",
-        "p"
+        "pseudo-LOCALE"
     ],
     "catalogs": [{
         "path": "src/locales/{locale}/messages",
@@ -20,6 +20,7 @@
     "orderBy": "origin",
     "sourceLocale": "en",
     "fallbackLocales": {
-        "default": "en"
+        "default": "en",
+        "pseudo-LOCALE": "en"
     }
 }

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/.linguirc
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/.linguirc
@@ -1,0 +1,25 @@
+{
+    "locales": [
+        "de",
+        "en",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ru",
+        "zh_Hans",
+        "zh_Hant",
+        "p"
+    ],
+    "catalogs": [{
+        "path": "src/locales/{locale}/messages",
+        "include": ["src"],
+        "exclude": ["**/node_modules/**", "./dist/**"]
+    }],
+    "format": "po",
+    "orderBy": "origin",
+    "sourceLocale": "en",
+    "fallbackLocales": {
+        "default": "en"
+    }
+}

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -7,6 +7,8 @@
     {% if cookiecutter.frontend.translation %}
     "extract": "lingui extract",
     "compile": "lingui compile --typescript",
+    "translate": "lingui extract && lingui compile --typescript",
+    {% else %}
     {% endif %}
     "lint": "npx @biomejs/biome check ./src",
     "lint:fix": "npx @biomejs/biome check ./src --fix",

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -24,6 +24,7 @@
     "@lingui/cli": "latest",
     "@lingui/macro": "latest",
     "@lingui/babel-plugin-lingui-macro": "latest",
+    "@lingui/vite-plugin": "latest",
     {%- endif %}
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -21,8 +21,11 @@
   "peerDependencies": {},
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
+    {% if cookiecutter.frontend.translation %}
     "@lingui/cli": "latest",
     "@lingui/macro": "latest",
+    "@lingui/babel-plugin-lingui-macro": "latest",
+    {% endif %}
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vitejs/plugin-react": "^4.3.4",

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "npx @biomejs/biome check ./src",
     "lint:fix": "npx @biomejs/biome check ./src --fix",
     "build": "tsc -b && vite build --emptyOutDir",
-    "dev": "vite --config vite.dev.config.ts --host",
+    "dev": "vite --config vite.dev.config.ts --host"
   },
   "dependencies": {
     "@inventreedb/ui": "latest"

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -23,8 +23,10 @@
     {% if cookiecutter.frontend.translation -%}
     "@lingui/cli": "latest",
     "@lingui/macro": "latest",
-    "@lingui/babel-plugin-lingui-macro": "latest",
+    "@lingui/swc-plugin": "latest",
     "@lingui/vite-plugin": "latest",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react-swc": "latest",
     {%- endif %}
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -4,12 +4,14 @@
   "version": "{{ cookiecutter.plugin_version }}",
   "type": "module",
   "scripts": {
+    {% if cookiecutter.frontend.translation %}
+    "extract": "lingui extract",
+    "compile": "lingui compile --typescript",
+    {% endif %}
     "lint": "npx @biomejs/biome check ./src",
     "lint:fix": "npx @biomejs/biome check ./src --fix",
     "build": "tsc -b && vite build --emptyOutDir",
     "dev": "vite --config vite.dev.config.ts --host",
-    "extract": "lingui extract",
-    "compile": "lingui compile --typescript"
   },
   "dependencies": {
     "@inventreedb/ui": "latest"

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -7,7 +7,9 @@
     "lint": "npx @biomejs/biome check ./src",
     "lint:fix": "npx @biomejs/biome check ./src --fix",
     "build": "tsc -b && vite build --emptyOutDir",
-    "dev": "vite --config vite.dev.config.ts --host"
+    "dev": "vite --config vite.dev.config.ts --host",
+    "extract": "lingui extract",
+    "compile": "lingui compile --typescript"
   },
   "dependencies": {
     "@inventreedb/ui": "latest"

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -4,12 +4,11 @@
   "version": "{{ cookiecutter.plugin_version }}",
   "type": "module",
   "scripts": {
-    {% if cookiecutter.frontend.translation %}
+    {% if cookiecutter.frontend.translation -%}
     "extract": "lingui extract",
     "compile": "lingui compile --typescript",
     "translate": "lingui extract && lingui compile --typescript",
-    {% else %}
-    {% endif %}
+    {%- endif %}
     "lint": "npx @biomejs/biome check ./src",
     "lint:fix": "npx @biomejs/biome check ./src --fix",
     "build": "tsc -b && vite build --emptyOutDir",
@@ -21,11 +20,11 @@
   "peerDependencies": {},
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
-    {% if cookiecutter.frontend.translation %}
+    {% if cookiecutter.frontend.translation -%}
     "@lingui/cli": "latest",
     "@lingui/macro": "latest",
     "@lingui/babel-plugin-lingui-macro": "latest",
-    {% endif %}
+    {%- endif %}
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vitejs/plugin-react": "^4.3.4",

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/package.json
@@ -25,7 +25,6 @@
     "@lingui/macro": "latest",
     "@lingui/swc-plugin": "latest",
     "@lingui/vite-plugin": "latest",
-    "@vitejs/plugin-react": "^4.3.4",
     "@vitejs/plugin-react-swc": "latest",
     {%- endif %}
     "@types/react": "latest",

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -5,14 +5,11 @@ import { notifications } from '@mantine/notifications';
 import { useQuery } from '@tanstack/react-query';
 {%- endif %}
 
-{% if cookiecutter.frontend.translation %}
-import { i18n } from '@lingui/core';
+{% if cookiecutter.frontend.translation -%}
 import { Trans } from '@lingui/react/macro';
+import loadPluginLocale from './locales.tsx';
+{%- endif %}
 
-// Translation support
-import { messages as deMessages } from './locales/de/messages.ts';
-import { messages as esMessages } from './locales/es/messages.ts';
-{% endif %}
 
 // Import for type checking
 import { checkPluginVersion, type InvenTreePluginContext } from '@inventreedb/ui';
@@ -154,13 +151,10 @@ function {{ cookiecutter.plugin_name }}Panel({
 export function render{{ cookiecutter.plugin_name }}Panel(context: InvenTreePluginContext) {
     checkPluginVersion(context);
 
-    {% if cookiecutter.frontend.translation %}
-    // Set up translations (if required)
-    i18n.load({
-        de: deMessages,
-        es: esMessages
-    });
-    {% endif %}
+    {% if cookiecutter.frontend.translation -%}
+    // Load plugin translations dynamically based on the locale
+    loadPluginLocale(context.locale);
+    {%- endif %}
 
     return <{{ cookiecutter.plugin_name }}Panel context={context} />;
 }

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -7,8 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 
 {% if cookiecutter.frontend.translation -%}
 import { t } from '@lingui/core/macro';
-import { I18nProvider } from '@lingui/react';
-import loadPluginLocale from './locale.tsx';
+import { LocalizedComponent } from './locale';
 {%- endif %}
 
 // Import for type checking
@@ -161,39 +160,6 @@ function {{ cookiecutter.plugin_name }}Panel({
     );
 }
 
-{% if cookiecutter.frontend.translation -%}
-// Wrapper component to ensure translations are loaded correctly
-function {{ cookiecutter.plugin_name }}LocalizedPanel({
-    context
-}: {
-    context: InvenTreePluginContext;
-}) {
-
-    const [loaded, setLoaded] = useState(false);
-
-    // Reload componentwhen the locale changes
-    useEffect(() => {
-        setLoaded(false);
-        loadPluginLocale(context.locale).then(() => {
-            setLoaded(true);
-        });
-    }, [context.locale]);
-
-    if (!loaded) {
-        return (
-            <Skeleton w='100%' animate />
-        )
-    }
-
-    return (
-        <I18nProvider i18n={context.i18n}>
-            <{{ cookiecutter.plugin_name }}Panel context={context} />
-        </I18nProvider>
-    );
-}
-
-{%- endif %}
-
 
 // This is the function which is called by InvenTree to render the actual panel component
 export function render{{ cookiecutter.plugin_name }}Panel(context: InvenTreePluginContext) {
@@ -201,7 +167,9 @@ export function render{{ cookiecutter.plugin_name }}Panel(context: InvenTreePlug
 
     {% if cookiecutter.frontend.translation -%}
     return (
-        <{{ cookiecutter.plugin_name }}LocalizedPanel context={context} />
+        <LocalizedComponent locale={context.locale}>
+            <{{ cookiecutter.plugin_name }}Panel context={context} />
+        </LocalizedComponent>
     );
     {%- else -%}
     return (

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Alert, Button, Group, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 {% if "UrlsMixin" in cookiecutter.plugin_mixins.mixin_list -%}
 import { useQuery } from '@tanstack/react-query';
 {%- endif %}
 
 {% if cookiecutter.frontend.translation -%}
-import { Trans } from '@lingui/react/macro';
-import loadPluginLocale from './locales.tsx';
+import { t } from '@lingui/core/macro';
+import loadPluginLocale from './locale.tsx';
 {%- endif %}
 
 
@@ -99,7 +99,11 @@ function {{ cookiecutter.plugin_name }}Panel({
         </Text>
         {% if cookiecutter.frontend.translation %}
         <Alert title='Translated Text' color='grape'>
-          <Trans>Translated text, provided by custom code!</Trans>
+            <Stack gap='xs'>
+                <Text>{t`Translated text, provided by custom code!`}</Text>
+                <Text>{t`Translations are loaded automatically.`}</Text>
+                <Text>{t`Fallback locale is used if no translation is available`}</Text>
+            </Stack>
          </Alert>
         {% endif %}
         <Group justify='apart' wrap='nowrap' gap='sm'>
@@ -114,34 +118,36 @@ function {{ cookiecutter.plugin_name }}Panel({
             </Button>
             <Text size='xl'>Counter: {counter}</Text>
         </Group>
-        {instance ? (
-            <Alert title="Instance Data" color="blue">
-                {instance}
-            </Alert>
-        ) : (
-            <Alert title="No Instance" color="yellow">
-                No instance data available
-            </Alert>
-        )}
-        {% if "UrlsMixin" in cookiecutter.plugin_mixins.mixin_list -%}
-        {apiQuery.isFetched && apiQuery.data && (
-           <Alert color="green" title="API Query Data">
-                {apiQuery.isFetching || apiQuery.isLoading ? (
-                <Text>Loading...</Text>
-                ) : (
-                <Stack gap='xs'>
-                    <Text>Part Count: {apiQuery.data.part_count}</Text>
-                    <Text>Today: {apiQuery.data.today}</Text>
-                    <Text>Random Text: {apiQuery.data.random_text}</Text>
-                    <Button
-                        disabled={apiQuery.isFetching || apiQuery.isLoading}
-                        onClick={() => apiQuery.refetch()}>
-                        Reload Data
-                    </Button>
-                </Stack>
+        <SimpleGrid cols={2}>
+            {instance ? (
+                <Alert title="Instance Data" color="blue">
+                    {instance}
+                </Alert>
+            ) : (
+                <Alert title="No Instance" color="yellow">
+                    No instance data available
+                </Alert>
             )}
-        </Alert>
-        )}{%- endif %}
+            {% if "UrlsMixin" in cookiecutter.plugin_mixins.mixin_list -%}
+            {apiQuery.isFetched && apiQuery.data && (
+            <Alert color="green" title="API Query Data">
+                    {apiQuery.isFetching || apiQuery.isLoading ? (
+                    <Text>Loading...</Text>
+                    ) : (
+                    <Stack gap='xs'>
+                        <Text>Part Count: {apiQuery.data.part_count}</Text>
+                        <Text>Today: {apiQuery.data.today}</Text>
+                        <Text>Random Text: {apiQuery.data.random_text}</Text>
+                        <Button
+                            disabled={apiQuery.isFetching || apiQuery.isLoading}
+                            onClick={() => apiQuery.refetch()}>
+                            Reload Data
+                        </Button>
+                    </Stack>
+                )}
+            </Alert>
+            )}{%- endif %}
+        </SimpleGrid>
         </Stack>
         </>
     );

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 
 {% if cookiecutter.frontend.translation %}
 import { i18n } from '@lingui/core';
-import { Trans } from '@lingui/react';
+import { Trans } from '@lingui/react/macro';
 
 // Translation support
 import { messages as deMessages } from './locales/de/messages.ts';
@@ -102,11 +102,8 @@ function {{ cookiecutter.plugin_name }}Panel({
         </Text>
         {% if cookiecutter.frontend.translation %}
         <Alert title='Translated Text' color='grape'>
-          <Trans
-            id='panel.greeting'
-            message='Translated text, provided by custom code!'
-          />
-        </Alert>
+          <Trans>Translated text, provided by custom code!</Trans>
+         </Alert>
         {% endif %}
         <Group justify='apart' wrap='nowrap' gap='sm'>
             <Button color='blue' onClick={gotoDashboard}>

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, Button, Group, SimpleGrid, Skeleton, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 {% if "UrlsMixin" in cookiecutter.plugin_mixins.mixin_list -%}
 import { useQuery } from '@tanstack/react-query';

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locale.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locale.tsx
@@ -1,0 +1,14 @@
+
+import { i18n } from '@lingui/core';
+
+
+/**
+ * Helper function to dynamically load frontend translations,
+ * based on the provided locale.
+ */
+export default async function loadPluginLocale(locale: string) {
+    const { messages } = await import(`./locales/${locale}/messages.ts`);
+    
+    i18n.load(locale, messages);
+    i18n.activate(locale);
+}

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locale.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locale.tsx
@@ -1,14 +1,50 @@
 
 import { i18n } from '@lingui/core';
+import { Skeleton } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { I18nProvider } from '@lingui/react';
 
 
 /**
  * Helper function to dynamically load frontend translations,
  * based on the provided locale.
  */
-export default async function loadPluginLocale(locale: string) {
+async function loadPluginLocale(locale: string) {
     const { messages } = await import(`./locales/${locale}/messages.ts`);
     
     i18n.load(locale, messages);
     i18n.activate(locale);
+}
+
+
+// Wrapper component for loading dynamic translations
+export function LocalizedComponent({
+    locale,
+    children
+}: {
+    locale: string,
+    children: React.ReactNode
+}) {
+
+    const [loaded, setLoaded] = useState(false);
+
+    // Reload componentwhen the locale changes
+    useEffect(() => {
+        setLoaded(false);
+        loadPluginLocale(locale).then(() => {
+            setLoaded(true);
+        });
+    }, [locale]);
+
+    if (!loaded) {
+        return (
+            <Skeleton w='100%' animate />
+        );
+    }
+
+    return (
+        <I18nProvider i18n={i18n}>
+            {children}
+        </I18nProvider>
+    );
 }

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/de/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/de/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/de/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/de/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-05 13:54+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/Panel.tsx:96
+msgid "Translated Text"
+msgstr "Übersetzter Text"
+
+#: src/Panel.tsx:97
+msgid "Translated text, provided by custom code!"
+msgstr "Übersetzter Text, bereitgestellt durch benutzerdefinierten Code!"
+
+#: src/Panel.tsx:98
+msgid "Translations are loaded automatically."
+msgstr "Übersetzungen werden automatisch geladen"
+
+#: src/Panel.tsx:99
+msgid "Fallback locale is used if no translation is available"
+msgstr ""

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/de/messages.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/de/messages.ts
@@ -1,3 +1,0 @@
-export const messages = {
-    "panel.greeting": "Übersetzter Text, bereitgestellt durch benutzerdefinierten Code!"
-}

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/en/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/en/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/en/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/en/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-05 13:54+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/Panel.tsx:96
+msgid "Translated Text"
+msgstr "Translated Text"
+
+#: src/Panel.tsx:97
+msgid "Translated text, provided by custom code!"
+msgstr "Translated text, provided by custom code!"
+
+#: src/Panel.tsx:98
+msgid "Translations are loaded automatically."
+msgstr "Translations are loaded automatically."
+
+#: src/Panel.tsx:99
+msgid "Fallback locale is used if no translation is available"
+msgstr "Fallback locale is used if no translation is available"

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/es/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/es/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/es/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/es/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-05 13:54+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/Panel.tsx:96
+msgid "Translated Text"
+msgstr "Texto traducido"
+
+#: src/Panel.tsx:97
+msgid "Translated text, provided by custom code!"
+msgstr "¡Texto traducido, proporcionado por código personalizado!"
+
+#: src/Panel.tsx:98
+msgid "Translations are loaded automatically."
+msgstr "Las traducciones se cargan automáticamente"
+
+#: src/Panel.tsx:99
+msgid "Fallback locale is used if no translation is available"
+msgstr ""

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/es/messages.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/es/messages.ts
@@ -1,3 +1,0 @@
-export const messages = {
-    "panel.greeting": "¡Texto traducido, proporcionado por código personalizado!"
-};

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/fr/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/fr/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/fr/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/fr/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-05 13:54+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/Panel.tsx:96
+msgid "Translated Text"
+msgstr "Texte traduit"
+
+#: src/Panel.tsx:97
+msgid "Translated text, provided by custom code!"
+msgstr "Texte traduit, fourni par un code personnalisé !"
+
+#: src/Panel.tsx:98
+msgid "Translations are loaded automatically."
+msgstr "Les traductions sont chargées automatiquement."
+
+#: src/Panel.tsx:99
+msgid "Fallback locale is used if no translation is available"
+msgstr ""

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/it/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/it/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/it/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/it/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-05 13:54+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: it\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/Panel.tsx:96
+msgid "Translated Text"
+msgstr "Testo tradotto"
+
+#: src/Panel.tsx:97
+msgid "Translated text, provided by custom code!"
+msgstr "Testo tradotto, fornito tramite codice personalizzato!"
+
+#: src/Panel.tsx:98
+msgid "Translations are loaded automatically."
+msgstr "Le traduzioni vengono caricate automaticamente."
+
+#: src/Panel.tsx:99
+msgid "Fallback locale is used if no translation is available"
+msgstr ""

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/ja/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/ja/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/ja/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/ja/messages.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-05 13:54+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ja\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/Panel.tsx:96
+msgid "Translated Text"
+msgstr "翻訳されたテキスト"
+
+#: src/Panel.tsx:97
+msgid "Translated text, provided by custom code!"
+msgstr ""
+
+#: src/Panel.tsx:98
+msgid "Translations are loaded automatically."
+msgstr ""
+
+#: src/Panel.tsx:99
+msgid "Fallback locale is used if no translation is available"
+msgstr ""

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/pseudo-LOCALE/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/pseudo-LOCALE/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/pseudo-LOCALE/messages.po
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/pseudo-LOCALE/messages.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2025-08-13 10:52+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: pseudo-LOCALE\n"
+
+#: src/Panel.tsx:104
+msgid "Translated text, provided by custom code!"
+msgstr ""
+
+#: src/Panel.tsx:105
+msgid "Translations are loaded automatically."
+msgstr ""
+
+#: src/Panel.tsx:106
+msgid "Fallback locale is used if no translation is available"
+msgstr ""

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/pseudo-LOCALE/messages.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/pseudo-LOCALE/messages.ts
@@ -1,0 +1,1 @@
+/*eslint-disable*/import type{Messages}from"@lingui/core";export const messages=JSON.parse("{\"4Yq+pa\":[\"Translated Text\"],\"L8ZD4/\":[\"Fallback locale is used if no translation is available\"],\"OPk5rd\":[\"Translated text, provided by custom code!\"],\"ehDjBq\":[\"Translations are loaded automatically.\"]}")as Messages;

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/ru/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/ru/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/zh_Hans/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/zh_Hans/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/zh_Hant/messages.d.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/locales/zh_Hant/messages.d.ts
@@ -1,0 +1,4 @@
+import { Messages } from '@lingui/core';
+          declare const messages: Messages;
+          export { messages };
+          

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
@@ -29,12 +29,17 @@ const externalKeys = Object.keys(externalLibs);
  */
 export default defineConfig({
   plugins: [
-    react({
-      jsxRuntime: 'classic',
-    }),
     {% if cookiecutter.frontend.translation -%}
     lingui(),
     {%- endif %}
+    react({
+      jsxRuntime: 'classic',
+      {% if cookiecutter.frontend.translation -%}
+      babel: {
+        plugins: ['macros'], // Required for @lingui macros
+      },
+      {%- endif %}
+    }),
     viteExternalsPlugin(externalLibs),
   ],
   esbuild: {

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
@@ -30,7 +30,7 @@ const externalKeys = Object.keys(externalLibs);
 export default defineConfig({
   plugins: [
     react({
-      jsxRuntime: 'classic'
+      jsxRuntime: 'classic',
     }),
     {% if cookiecutter.frontend.translation -%}
     lingui(),

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { viteExternalsPlugin } from 'vite-plugin-externals'
+{% if cookiecutter.frontend.translation -%}
+import { lingui } from "@lingui/vite-plugin";
+{%- endif %}
 
 
 /**
@@ -29,6 +32,9 @@ export default defineConfig({
     react({
       jsxRuntime: 'classic'
     }),
+    {% if cookiecutter.frontend.translation -%}
+    lingui(),
+    {%- endif %}
     viteExternalsPlugin(externalLibs),
   ],
   esbuild: {

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
@@ -1,8 +1,12 @@
 // Primary vite config - we extend this for dev mode
 import { defineConfig } from 'vite'
 import { viteExternalsPlugin } from 'vite-plugin-externals'
-
 import viteConfig, { externalLibs } from './vite.config'
+
+{% if cookiecutter.frontend.translation -%}
+import react from "@vitejs/plugin-react-swc"
+import { lingui } from "@lingui/vite-plugin"
+{%- endif %}
 
 /**
  * Vite config to run the frontend plugin in development mode.
@@ -33,6 +37,12 @@ export default defineConfig((cfg) => {
   delete config.optimizeDeps;
 
   config.plugins = [
+    {% if cookiecutter.frontend.translation -%}
+    lingui(),
+    react({
+      plugins: [["@lingui/swc-plugin", {}]]
+    }),
+    {%- endif %}
     viteExternalsPlugin(externalLibs),
   ];
 


### PR DESCRIPTION
This PR adds translation support for plugins, allowing dynamic reloading of localized plugin components

- Closes https://github.com/inventree/plugin-creator/issues/67

### Tasks

- [x] Add extraction step
- [x] Update generated CI files to extract and compile frontend translations
- [x] Ensure compiled translations are distributed when building frontend for production
- [x] Add "sample" translations to the getting-started plugin code
- [x] Check for compiled translation files as part of CI
- [x] Load new translations into code
- [ ] Update inventree docs