### PR TITLE
Generate two rollup outputs:

### DIFF
--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.config.ts
@@ -64,12 +64,23 @@ export default defineConfig({
         './src/Settings.tsx',
         {%- endif %}
       ],
-      output: {
-        dir: '../{{ cookiecutter.package_name }}/static',
-        entryFileNames: '[name].js',
-        assetFileNames: 'assets/[name].[ext]',
-        globals: externalLibs,
-      },
+      output: [
+        // Generate two sets of output files:
+        // One without hashes - for backwards compatibility
+        {
+          dir: '../{{ cookiecutter.package_name }}/static',
+          entryFileNames: '[name].js',
+          assetFileNames: 'assets/[name].[ext]',
+          globals: externalLibs,
+        },
+        // And one with hashes for cache busting
+        {
+          dir: '../{{ cookiecutter.package_name }}/static',
+          entryFileNames: '[name]-[hash].js',
+          assetFileNames: 'assets/[name].[ext]',
+          globals: externalLibs,
+        }
+      ],
       external: externalKeys,
     }
   },


### PR DESCRIPTION
- Hashed version for cache busting
- Non-hashed version for backwards compatibility

This feature is added to support "cache busting" for plugin static files by hashing the rollup outputs.

However this only will work with new InvenTree code (1.3.0 or newer) which can perform lookup of hashed static files. So, for backwards compatibility, a non-hashed output is generated too.

Ref: https://github.com/inventree/InvenTree/pull/11565