### PR TITLE
Add HMR and React Fast Refresh support

### DIFF
--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Dashboard.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Dashboard.tsx
@@ -38,7 +38,7 @@ function {{ cookiecutter.plugin_name }}DashboardItem({
 
 // This is the function which is called by InvenTree to render the actual dashboard
 //  component
-export function render{{ cookiecutter.plugin_name }}DashboardItem(context: InvenTreePluginContext) {
+export function Render{{ cookiecutter.plugin_name }}DashboardItem(context: InvenTreePluginContext) {
     checkPluginVersion(context);
     return <{{ cookiecutter.plugin_name }}DashboardItem context={context} />;
 }

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Panel.tsx
@@ -249,7 +249,7 @@ function {{ cookiecutter.plugin_name }}Panel({
 }
 
 // This is the function which is called by InvenTree to render the actual panel component
-export function render{{ cookiecutter.plugin_name }}Panel(context: InvenTreePluginContext) {
+export function Render{{ cookiecutter.plugin_name }}Panel(context: InvenTreePluginContext) {
     checkPluginVersion(context);
 
     {% if cookiecutter.frontend.translation -%}

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Settings.tsx
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/src/Settings.tsx
@@ -27,7 +27,7 @@ function PluginSettingsDisplay({
 }
 
 
-export function renderPluginSettings(context: InvenTreePluginContext) {
+export function RenderPluginSettings(context: InvenTreePluginContext) {
     return (
         <PluginSettingsDisplay context={context} />
     );

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
@@ -10,6 +10,7 @@ import { lingui } from "@lingui/vite-plugin"
 
 import type { ResolvedConfig, Plugin } from 'vite'
 
+// Enable HMR support for this plugin by hooking into the InvenTree vite dev server
 function inventreeHmrPlugin(): Plugin {
   let isDev = false;
 

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
@@ -1,5 +1,5 @@
 // Primary vite config - we extend this for dev mode
-import { defineConfig } from 'vite'
+import { defineConfig, Plugin } from 'vite'
 import { viteExternalsPlugin } from 'vite-plugin-externals'
 import viteConfig, { externalLibs } from './vite.config'
 
@@ -7,6 +7,32 @@ import viteConfig, { externalLibs } from './vite.config'
 import react from "@vitejs/plugin-react-swc"
 import { lingui } from "@lingui/vite-plugin"
 {%- endif %}
+
+function inventreeHmrPlugin(): Plugin {
+  const fileRegex = /\.(js|jsx|ts|tsx)(\?|$)/;
+
+  const hmrBlock = [
+    '',
+    '// __inventree_hmr_injected__',
+    'if (import.meta.hot) {',
+    '  import.meta.hot.accept((newModule) => {',
+    '    window.__plugin_hmr_reload?.(newModule);',
+    '  })',
+    '}',
+  ];
+
+  return {
+    name: 'inventree-hmr-plugin',
+
+    transform(code, id) {
+      if (!fileRegex.test(id)) return;
+      if (id.includes("node_modules")) return;
+      if (code.includes("__inventree_hmr_injected__")) return;
+
+      return code + hmrBlock.join('\n');
+    }
+  }
+}
 
 /**
  * Vite config to run the frontend plugin in development mode.
@@ -40,10 +66,12 @@ export default defineConfig((cfg) => {
     {% if cookiecutter.frontend.translation -%}
     lingui(),
     react({
-      plugins: [["@lingui/swc-plugin", {}]]
+      plugins: [["@lingui/swc-plugin", {}]],
+      reactRefreshHost: 'http://localhost:5173',
     }),
     {%- endif %}
     viteExternalsPlugin(externalLibs),
+    inventreeHmrPlugin(),
   ];
 
   return config;

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
@@ -1,5 +1,5 @@
 // Primary vite config - we extend this for dev mode
-import { defineConfig, Plugin } from 'vite'
+import { defineConfig } from 'vite'
 import { viteExternalsPlugin } from 'vite-plugin-externals'
 import viteConfig, { externalLibs } from './vite.config'
 
@@ -8,7 +8,11 @@ import react from "@vitejs/plugin-react-swc"
 import { lingui } from "@lingui/vite-plugin"
 {%- endif %}
 
+import type { ResolvedConfig, Plugin } from 'vite'
+
 function inventreeHmrPlugin(): Plugin {
+  let isDev = false;
+
   const fileRegex = /\.(js|jsx|ts|tsx)(\?|$)/;
 
   const hmrBlock = [
@@ -16,20 +20,29 @@ function inventreeHmrPlugin(): Plugin {
     '// __inventree_hmr_injected__',
     'if (import.meta.hot) {',
     '  import.meta.hot.accept((newModule) => {',
-    '    window.__plugin_hmr_reload?.(newModule);',
+    '    window.__plugin_hmr_reload?.({mod: newModule, url: import.meta.url});',
     '  })',
     '}',
   ];
 
   return {
     name: 'inventree-hmr-plugin',
+    enforce: 'post',
+
+    configResolved(config: ResolvedConfig) {
+      isDev = config.command === 'serve';
+    },
 
     transform(code, id) {
+      if (!isDev) return;
       if (!fileRegex.test(id)) return;
-      if (id.includes("node_modules")) return;
-      if (code.includes("__inventree_hmr_injected__")) return;
+      if (id.includes('node_modules')) return;
+      if (code.includes('__inventree_hmr_injected__')) return;
 
-      return code + hmrBlock.join('\n');
+      return {
+        code: code + hmrBlock.join('\n'),
+        map: null,
+      }
     }
   }
 }

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/frontend/vite.dev.config.ts
@@ -8,12 +8,10 @@ import react from "@vitejs/plugin-react-swc"
 import { lingui } from "@lingui/vite-plugin"
 {%- endif %}
 
-import type { ResolvedConfig, Plugin } from 'vite'
+import type { Plugin } from 'vite'
 
 // Enable HMR support for this plugin by hooking into the InvenTree vite dev server
 function inventreeHmrPlugin(): Plugin {
-  let isDev = false;
-
   const fileRegex = /\.(js|jsx|ts|tsx)(\?|$)/;
 
   const hmrBlock = [
@@ -21,7 +19,10 @@ function inventreeHmrPlugin(): Plugin {
     '// __inventree_hmr_injected__',
     'if (import.meta.hot) {',
     '  import.meta.hot.accept((newModule) => {',
-    '    window.__plugin_hmr_reload?.({mod: newModule, url: import.meta.url});',
+    '    const key = new URL(import.meta.url).origin + new URL(import.meta.url).pathname;',
+    '    window.__plugin_hmr_callbacks?.[key]?.forEach(callback => {',
+    '      callback(newModule);',
+    '    });',
     '  })',
     '}',
   ];
@@ -30,12 +31,7 @@ function inventreeHmrPlugin(): Plugin {
     name: 'inventree-hmr-plugin',
     enforce: 'post',
 
-    configResolved(config: ResolvedConfig) {
-      isDev = config.command === 'serve';
-    },
-
     transform(code, id) {
-      if (!isDev) return;
       if (!fileRegex.test(id)) return;
       if (id.includes('node_modules')) return;
       if (code.includes('__inventree_hmr_injected__')) return;

--- a/plugin_creator/template/{{ cookiecutter.plugin_name }}/{{ cookiecutter.package_name }}/core.py
+++ b/plugin_creator/template/{{ cookiecutter.plugin_name }}/{{ cookiecutter.package_name }}/core.py
@@ -42,7 +42,7 @@ class {{ cookiecutter.plugin_name }}(InvenTreePlugin):
     {% if "UserInterfaceMixin" in cookiecutter.plugin_mixins.mixin_list -%}
     {%- if cookiecutter.frontend.features.settings -%}
     # Render custom UI elements to the plugin settings page
-    ADMIN_SOURCE = "Settings.js:renderPluginSettings"
+    ADMIN_SOURCE = "Settings.js:RenderPluginSettings"
     {%- endif -%}
     {%- endif -%}
 
@@ -156,7 +156,7 @@ class {{ cookiecutter.plugin_name }}(InvenTreePlugin):
                 'title': '{{ cookiecutter.plugin_title }}',
                 'description': 'Custom panel description',
                 'icon': 'ti:mood-smile:outline',
-                'source': self.plugin_static_file('Panel.js:render{{ cookiecutter.plugin_name }}Panel'),
+                'source': self.plugin_static_file('Panel.js:Render{{ cookiecutter.plugin_name }}Panel'),
                 'context': {
                     # Provide additional context data to the panel
                     {%- if "SettingsMixin" in cookiecutter.plugin_mixins.mixin_list %}
@@ -185,7 +185,7 @@ class {{ cookiecutter.plugin_name }}(InvenTreePlugin):
             'title': '{{ cookiecutter.plugin_title }} Dashboard Item',
             'description': 'Custom dashboard item',
             'icon': 'ti:dashboard:outline',
-            'source': self.plugin_static_file('Dashboard.js:render{{ cookiecutter.plugin_name }}DashboardItem'),
+            'source': self.plugin_static_file('Dashboard.js:Render{{ cookiecutter.plugin_name }}DashboardItem'),
             'context': {
                 # Provide additional context data to the dashboard item
                 {%- if "SettingsMixin" in cookiecutter.plugin_mixins.mixin_list %}
@@ -207,7 +207,9 @@ class {{ cookiecutter.plugin_name }}(InvenTreePlugin):
                 'title': 'Hello Action',
                 'description': 'Hello from {{ cookiecutter.plugin_name }}',
                 'icon': 'ti:heart-handshake:outline',
-                'source': self.plugin_static_file('Spotlight.js:{{ cookiecutter.plugin_name }}SpotlightAction'),
+                'source': self.plugin_static_file(
+                    'Spotlight.js:{{ cookiecutter.plugin_name[0]|upper }}{{ cookiecutter.plugin_name[1:] }}SpotlightAction'
+                ),
             }
         ]
     {%- endif -%}


### PR DESCRIPTION
Together with the InvenTree PR (https://github.com/inventree/InvenTree/pull/12060), this enables HMR to work correctly, including react fast refresh.

The `inventreeHmrPlugin` Vite plugin is only needed for legacy plugins to be reloaded via Vite's HMR API. This may need a guard so that it only replaces a module if the names match, maybe the callback would be a good place for it.

For Fast Refresh to work, exported functions must be React components, so the hack of making the plugin entry exports start with a capital letter may not be ideal. Is there a reason not to export proper React components instead?